### PR TITLE
Fix branch/location/country validation (serious bug!)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
-  - jruby-19mode
   - jruby-head
-  - rbx-2.1.1
+  - rbx-2.6
 script: rspec

--- a/bic_validation.gemspec
+++ b/bic_validation.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport'
   gem.add_dependency 'banking_data'
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rubocop'

--- a/lib/bic_validation/bic.rb
+++ b/lib/bic_validation/bic.rb
@@ -20,9 +20,9 @@ module BicValidation
       country_codes.include? country
     end
 
-    def has_valid_branch_code?
+    def has_valid_location_code?
       # WTF? http://de.wikipedia.org/wiki/ISO_9362
-      country[0] =~ /[^01]/ && country[1] =~ /[^O]/
+      location[0] =~ /[^01]/ && location[1] =~ /[^O]/
     end
 
     def known?
@@ -34,7 +34,7 @@ module BicValidation
       of_valid_length? &&
         of_valid_format? &&
         has_valid_country_code? &&
-        has_valid_branch_code?
+        has_valid_location_code?
     end
 
     def invalid?

--- a/spec/bic_validation/bic_spec.rb
+++ b/spec/bic_validation/bic_spec.rb
@@ -80,7 +80,7 @@ module BicValidation
     end
 
     ['DEUTDEBB', 'CRESCHZZ10S', 'UBSWCHZH86N', 'OEKOATWWXXX',
-     'OEKOATWW'].each do |swift|
+     'OEKOATWW', 'BTRLRO22'].each do |swift|
       describe 'validity checks' do
         it "validates #{swift}" do
           bic = Bic.new(swift)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 require 'coveralls'
 require 'pry'
+require 'rspec/its'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
You've mixed up country, location and branch in a way which lets all ISO countries which have the letter "O" as the second letter always fail validation – most notably "RO" (Romania).

Furthermore, I've added the rspec-its gem as a development dependency to fix the test suite.

Thanks for considering a timely merge and version bump!
